### PR TITLE
to_redis_protocol should use bytesize and also zset should process one by one

### DIFF
--- a/lib/redis_migrator/redis_helper.rb
+++ b/lib/redis_migrator/redis_helper.rb
@@ -3,7 +3,7 @@ class Redis
 
     def to_redis_proto(*cmd)
       cmd.inject("*#{cmd.length}\r\n") {|acc, arg|
-        acc << "$#{arg.length}\r\n#{arg}\r\n"
+        acc << "$#{arg.to_s.bytesize}\r\n#{arg}\r\n"
       }
     end
 
@@ -23,29 +23,29 @@ class Redis
       value = redis.get(key)
       pipe << to_redis_proto("SET", key, value)
     end
-  
+
     def copy_hash(pipe, key)
       redis.hgetall(key).each do |field, value|
-        pipe << to_redis_proto("HSET", key, field, value) 
+        pipe << to_redis_proto("HSET", key, field, value)
       end
     end
-  
+
     def copy_list(pipe, key)
       redis.lrange(key, 0, -1).each do |value|
         pipe << to_redis_proto("LPUSH", key, value)
       end
     end
-  
+
     def copy_set(pipe, key)
       redis.smembers(key).each do |member|
         pipe << to_redis_proto("SADD", key, member)
       end
     end
-  
+
     def copy_zset(pipe, key)
-      redis.zrange(key, 0, -1, :with_scores => true).each_slice(2) do |member, score|
+      redis.zrange(key, 0, -1, :with_scores => true).each do |member, score|
         pipe << to_redis_proto("ZADD", key, score, member)
-      end 
+      end
     end
 
   end

--- a/redis_migrator.gemspec
+++ b/redis_migrator.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("./lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "redis_migrator"
-  s.version     = "0.0.1"
+  s.version     = "0.0.2"
   s.date        = "2012-07-05"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Artem Yankov"]
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency('redis', '>= 2.2.2')
+  s.add_dependency('redis', '>= 3.0.0')
 end

--- a/spec/mock_redis/lib/mock_redis/zset_methods.rb
+++ b/spec/mock_redis/lib/mock_redis/zset_methods.rb
@@ -136,7 +136,7 @@ class MockRedis
         else
           member
         end
-      end.flatten
+      end
     end
 
     def combine_weighted_zsets(keys, options, how)

--- a/spec/redis_helper_spec.rb
+++ b/spec/redis_helper_spec.rb
@@ -1,7 +1,7 @@
-describe Redis::Helper do 
+describe Redis::Helper do
   before do
-    Redis.should_receive(:new).any_number_of_times {|options|  
-      MockRedis.new(options) 
+    Redis.should_receive(:new).any_number_of_times {|options|
+      MockRedis.new(options)
     }
 
     @migrator = Redis::Migrator.new(["redis://localhost:6379"],
@@ -21,7 +21,7 @@ describe Redis::Helper do
   end
 
   it "should copy a hash" do
-    @r1.hmset("myhash", 
+    @r1.hmset("myhash",
       "first_name", "James",
       "last_name", "Randi",
       "age", "83")
@@ -40,7 +40,7 @@ describe Redis::Helper do
   end
 
   it "should copy a set" do
-    ('a'..'z').to_a.each { |val| @r1.sadd("myset", val) } 
+    ('a'..'z').to_a.each { |val| @r1.sadd("myset", val) }
 
     @migrator.copy_set(@pipe, "myset")
 
@@ -48,7 +48,7 @@ describe Redis::Helper do
   end
 
   it "should copy zset" do
-    ('a'..'z').to_a.each { |val| @r1.zadd("myzset", rand(100), val) } 
+    ('a'..'z').to_a.each { |val| @r1.zadd("myzset", rand(100), val) }
 
     @migrator.copy_zset(@pipe, "myzset")
 


### PR DESCRIPTION
 fix bug: to_redis_protocol should use bytesize and also zset should process one by one

Changes from the redis 3.0.0.
- The `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE` and `ZREVRANGEBYSCORE` commands
  now return an array containing `[String, Float]` pairs when
  `:with_scores => true` is passed.
